### PR TITLE
Bruk padding i stedet for margin for å hindre overriding fra nav-frontend

### DIFF
--- a/src/veileder/result/fant-få-kandidater/FantFåKandidater.less
+++ b/src/veileder/result/fant-få-kandidater/FantFåKandidater.less
@@ -12,11 +12,11 @@
     }
 
     &__overskrift {
-        margin-bottom: 1rem;
+        padding-bottom: 1rem;
     }
 
     &__ingress {
-        margin-bottom: 4rem;
+        padding-bottom: 4rem;
     }
 
     &__ikon,
@@ -32,7 +32,7 @@
     }
 
     &__valgte-kriterier-tittel {
-        margin-bottom: 0.75rem;
+        padding-bottom: 0.75rem;
     }
 
     &__kriterie-label {


### PR DESCRIPTION
![Screenshot 2020-05-08 at 15 48 23](https://user-images.githubusercontent.com/36694755/81412269-e770ff00-9143-11ea-8493-a3f55413cef2.png)

Margin blir noen ganger overridet av nav-frontend, se bilde. Én løsning er å bruke padding i stedet for margin. En annen er å være mer spesifikk enn de andre. 