### PR TITLE
Deaktiver mulighet til å sette kandidat som midlertidig utilgjengelig

### DIFF
--- a/src/kandidatside/fra-kandidatliste/KandidatsideMedLastetKandidatliste.tsx
+++ b/src/kandidatside/fra-kandidatliste/KandidatsideMedLastetKandidatliste.tsx
@@ -18,7 +18,9 @@ import Kandidatheader from '../header/Kandidatheader';
 import KandidatlisteAction from '../../kandidatliste/reducer/KandidatlisteAction';
 import KandidatlisteActionType from '../../kandidatliste/reducer/KandidatlisteActionType';
 import Kandidatmeny from '../meny/Kandidatmeny';
-import MidlertidigUtilgjengelig from '../midlertidig-utilgjengelig/MidlertidigUtilgjengelig';
+import MidlertidigUtilgjengelig, {
+    tillatRegistreringAvMidlertidigUtilgjengelig,
+} from '../midlertidig-utilgjengelig/MidlertidigUtilgjengelig';
 import StatusOgHendelser from '../../kandidatliste/kandidatrad/status-og-hendelser/StatusOgHendelser';
 import useMidlertidigUtilgjengelig from './useMidlertidigUtilgjengelig';
 import useNavigerbareKandidater from './useNavigerbareKandidater';
@@ -75,7 +77,7 @@ const KandidatsideMedLastetKandidatliste: FunctionComponent<Props> = ({
                 forrigeKandidat={lenkeTilForrige}
             />
             <Kandidatmeny cv={cv}>
-                {cv.kind === Nettstatus.Suksess && (
+                {tillatRegistreringAvMidlertidigUtilgjengelig && cv.kind === Nettstatus.Suksess && (
                     <MidlertidigUtilgjengelig
                         cv={cv.data}
                         midlertidigUtilgjengelig={tilgjengelighet}

--- a/src/kandidatside/fra-søk/KandidatsideFraSøkInner.tsx
+++ b/src/kandidatside/fra-søk/KandidatsideFraSøkInner.tsx
@@ -20,7 +20,9 @@ import useMidlertidigUtilgjengelig from '../fra-kandidatliste/useMidlertidigUtil
 import ForrigeNeste from '../header/forrige-neste/ForrigeNeste';
 import Kandidatheader from '../header/Kandidatheader';
 import Kandidatmeny from '../meny/Kandidatmeny';
-import MidlertidigUtilgjengelig from '../midlertidig-utilgjengelig/MidlertidigUtilgjengelig';
+import MidlertidigUtilgjengelig, {
+    tillatRegistreringAvMidlertidigUtilgjengelig,
+} from '../midlertidig-utilgjengelig/MidlertidigUtilgjengelig';
 import useNavigerbareKandidaterFraSøk from './useNavigerbareKandidaterFraSøk';
 
 type Props = {
@@ -105,7 +107,7 @@ const KandidatsideFraSøkInner: FunctionComponent<Props> = ({
                 forrigeKandidat={lenkeTilForrige}
             />
             <Kandidatmeny cv={cv}>
-                {cv.kind === Nettstatus.Suksess && (
+                {tillatRegistreringAvMidlertidigUtilgjengelig && cv.kind === Nettstatus.Suksess && (
                     <MidlertidigUtilgjengelig
                         cv={cv.data}
                         midlertidigUtilgjengelig={tilgjengelighet}

--- a/src/kandidatside/midlertidig-utilgjengelig/MidlertidigUtilgjengelig.tsx
+++ b/src/kandidatside/midlertidig-utilgjengelig/MidlertidigUtilgjengelig.tsx
@@ -19,6 +19,8 @@ import MidlertidigUtilgjengeligKnapp from './midlertidig-utilgjengelig-knapp/Mid
 import RegistrerMidlertidigUtilgjengelig from './registrer-midlertidig-utilgjengelig/RegistrerMidlertidigUtilgjengelig';
 import './MidlertidigUtilgjengelig.less';
 
+export const tillatRegistreringAvMidlertidigUtilgjengelig = false;
+
 type OwnProps = {
     cv: Cv;
     midlertidigUtilgjengelig?: Nettressurs<MidlertidigUtilgjengeligResponse>;


### PR DESCRIPTION
Denne PR-en fjerner bare knappen inne på kandidatsiden. Relevant kode bør slettes senere.